### PR TITLE
Add sweet.js dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   }],
   "bugs": {
     "url": "https://github.com/jlongster/jsx-reader/issues"
+  },
+  "dependencies": {
+    "sweet.js": "^0.7.0"
   }
 }


### PR DESCRIPTION
Wanted to execute your tests and it failed because of missing dependency information.
